### PR TITLE
[stop][spot] Add specific behaviour for one-time spot instance

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -99,6 +99,7 @@ resource "aws_iam_role_policy" "schedule_ec2" {
     "Statement": [
         {
             "Action": [
+                "ec2:DescribeSpotInstanceRequests",
                 "ec2:DescribeInstances",
                 "ec2:DescribeInstanceStatus",
                 "ec2:StopInstances",

--- a/package/scheduler/main.py
+++ b/package/scheduler/main.py
@@ -37,7 +37,11 @@ def lambda_handler(event, context):
         "CLOUDWATCH_ALARM_SCHEDULE"
     )
     for service, to_schedule in _strategy.items():
-        if to_schedule == "true":
+        if to_schedule in ("true", "terminate"):
             for aws_region in aws_regions:
                 strategy = service(aws_region)
-                getattr(strategy, schedule_action)(tag_key, tag_value)
+                if to_schedule == "terminate":
+                    action = to_schedule
+                else:
+                    action = schedule_action
+                getattr(strategy, action)(tag_key, tag_value)

--- a/tests/unit/test_asg_scheduler.py
+++ b/tests/unit/test_asg_scheduler.py
@@ -35,6 +35,7 @@ def test_list_autoscaling_group(aws_region, tag_key, tag_value, result_count):
         ("eu-west-2", [], 0),
     ]
 )
+@mock_ec2
 @mock_autoscaling
 def test_list_autoscaling_instance(aws_region, asg_name, result_count):
     """Verify list autoscaling instance function"""


### PR DESCRIPTION
Fix about 'SpotScheduler' which wasn't manage after refactoring
('terminate' value for 'SPOT_SCHEDULE' tag)

Add 'DescribeSpotInstanceRequests' privilege to be able to distinguish
one-time or persistent spot instance

For 'spot_handler', we only need to terminate one-time spot instance, so
a check is made to retrieve them

For 'instance_handler' + 'autoscaling_handler', during the stop process,
we can't stop one-time spot instance, so we filter them to avoid a
warning like this:
```
An error occurred (UnsupportedOperation) when calling the StopInstances operation:
You can't stop the Spot Instance 'i-XXXX' because it is associated with a one-time Spot Instance request.
You can only stop Spot Instances associated with persistent Spot Instance requests.
```