### PR TITLE
Enforce IAM policy creation

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -73,6 +73,12 @@ variable "ec2_schedule" {
   default     = false
 }
 
+variable "ec2_schedule_arn_resources" {
+  description = "Instance arn list from ec2 resources"
+  type        = list(string)
+  default     = null
+}
+
 variable "documentdb_schedule" {
   description = "Enable scheduling on documentdb resources"
   type        = bool


### PR DESCRIPTION
- enforce Iam policy creation
- add var ec2_schedule_arn_resources to support:
Iam policy resources:
arn:aws:ec2:<REGION>:<ACCOUNT_ID>:instance/*
- add aws_lambda_function_regions  to pass var aws_regions