### PR TITLE
ECS services scheduler - update task count

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -277,6 +277,7 @@ resource "aws_lambda_function" "this" {
       DOCUMENTDB_SCHEDULE             = tostring(var.documentdb_schedule)
       EC2_SCHEDULE                    = tostring(var.ec2_schedule)
       ECS_SCHEDULE                    = tostring(var.ecs_schedule)
+      ECS_TASK_DESIRED_COUNT          = tostring(var.ecs_task_desired_count)
       RDS_SCHEDULE                    = tostring(var.rds_schedule)
       REDSHIFT_SCHEDULE               = tostring(var.redshift_schedule)
       AUTOSCALING_SCHEDULE            = tostring(var.autoscaling_schedule)

--- a/package/scheduler/ecs_handler.py
+++ b/package/scheduler/ecs_handler.py
@@ -1,5 +1,6 @@
 """ecs service scheduler."""
 
+from os import getenv
 from typing import Dict, List
 
 import boto3
@@ -20,6 +21,7 @@ class EcsScheduler:
         else:
             self.ecs = boto3.client("ecs")
         self.tag_api = FilterByTags(region_name=region_name)
+        self.ecs_task_desired_count = int(getenv("ECS_TASK_DESIRED_COUNT"))
 
     def stop(self, aws_tags: List[Dict]) -> None:
         """Aws ecs instance stop function.
@@ -72,7 +74,7 @@ class EcsScheduler:
             cluster_name = service_arn.split("/")[-2]
             try:
                 self.ecs.update_service(
-                    cluster=cluster_name, service=service_name, desiredCount=1
+                    cluster=cluster_name, service=service_name, desiredCount=self.ecs_task_desired_count
                 )
                 print(f"Start ECS Service {service_name} on Cluster {cluster_name}")
             except ClientError as exc:

--- a/variables.tf
+++ b/variables.tf
@@ -85,6 +85,12 @@ variable "ecs_schedule" {
   default     = false
 }
 
+variable "ecs_task_desired_count" {
+  description = "Enable scheduling on ecs services"
+  type        = number
+  default     = 1
+}
+
 variable "rds_schedule" {
   description = "Enable scheduling on rds resources"
   type        = any


### PR DESCRIPTION
Allows to define ECS' desired task count (has been hard coded).
Introduces new environment variable `ECS_TASK_DESIRED_COUNT`.